### PR TITLE
Add rule for text white (chat options - II)

### DIFF
--- a/instagram.user.styl
+++ b/instagram.user.styl
@@ -463,7 +463,7 @@ rad() { border-radius: arguments }
 
         /// DMs -> Active chat.
         .QOqBd { c: 0 0 bd }
-
+ 
         /// DMs -> Input bar.
         /.X3a-9 { c: 0 0 bg }
 
@@ -471,6 +471,13 @@ rad() { border-radius: arguments }
         .CMoMH {
             &:not(._6FEQj) { c: 0 0 bg }
             &._6FEQj { c: 0 0 bd }
+        }
+        /// DMs -> Message options
+        .sqdOP{
+            color:#fff !important
+         }
+        .M8ipN{
+            color:#fff !important
         }
 
         /// Footer -> Sent message.


### PR DESCRIPTION
In chat, when you want to delete a message, the text was black, and these changes are going to be white.